### PR TITLE
Makefile: improve install target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ sqlite2mdoc.tar.gz.sha512: sqlite2mdoc.tar.gz
 main.o: config.h
 
 install:
-	mkdir -p $(DESTDIR)$(PREFIX)/bin
-	mkdir -p $(DESTDIR)$(PREFIX)/man/man1
-	$(INSTALL_PROGRAM) sqlite2mdoc $(DESTDIR)$(PREFIX)/bin
-	$(INSTALL_MAN) -m 0444 sqlite2mdoc.1 $(DESTDIR)$(PREFIX)/man/man1
+	mkdir -p $(DESTDIR)$(BINDIR)
+	mkdir -p $(DESTDIR)$(MANDIR)
+	$(INSTALL_PROGRAM) sqlite2mdoc $(DESTDIR)$(BINDIR)
+	$(INSTALL_MAN) sqlite2mdoc.1 $(DESTDIR)$(MANDIR)
 
 distcheck: sqlite2mdoc.tar.gz sqlite2mdoc.tar.gz.sha512
 	mandoc -Tlint -Werror sqlite2mdoc.1


### PR DESCRIPTION
Newer versions of oconfigure set BINDIR/MANDIR respectively, so use
those. The permission bits for the manpage are removed, as INSTALL_MAN
uses the same permissions.

It would also be nice for oconfigure to check the value of prefix, so that PREFIX="/usr" -> MANDIR="/usr/share/man" instead of just "/usr/man".